### PR TITLE
Thumbnails should keep the aspect ratio and not squeeze when screen size is below 998px

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,3 +25,8 @@
 - Place: Coventry, UK
 - GitHub: [LeeConnelly12](https://github.com/LeeConnelly12)
 
+#### Name: [Junaid Anwar](https://github.com/Juni4567)
+
+- Role: Contributor
+- Place: Rawalpindi, Pakistan
+- GitHub: [Juni4567](https://github.com/Juni4567)

--- a/main/src/App.css
+++ b/main/src/App.css
@@ -183,7 +183,7 @@ ul li{
 
   .item-image {
     width: 266px;
-    height: 200px;
+    height: auto;
   }
 
   .headerContainer {


### PR DESCRIPTION
Issue can be seen here:
https://gyazo.com/9961ca7c20494eb40e7ad1e043f6c864