### PR TITLE
Replace `theme.spacing.unit x` with `theme.spacing(x)` using jscodeshift

### DIFF
--- a/main/src/App.js
+++ b/main/src/App.js
@@ -19,9 +19,9 @@ var data = content;
 
 const styles = theme => ({
   content: {
-    marginTop: `${theme.spacing.unit * 2 + 54}px`,
+    marginTop: `${theme.spacing(2) + 54}px`,
     [theme.breakpoints.up('sm')]: {
-      marginTop: `${theme.spacing.unit * 2 + 64}px`
+      marginTop: `${theme.spacing(2) + 64}px`
     }
   },
   error: {

--- a/main/src/components/autocomplete.js
+++ b/main/src/components/autocomplete.js
@@ -20,7 +20,7 @@ const styles = theme => ({
   paper: {
     position: 'absolute',
     zIndex: 1,
-    marginTop: theme.spacing.unit,
+    marginTop: theme.spacing(1),
     left: 0,
     right: 0
   },
@@ -31,14 +31,14 @@ const styles = theme => ({
   inputInput: {
     width: 'auto',
     flexGrow: 1,
-    paddingTop: theme.spacing.unit,
-    paddingRight: theme.spacing.unit,
-    paddingBottom: theme.spacing.unit,
-    paddingLeft: theme.spacing.unit * 10,
+    paddingTop: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(10),
     transition: theme.transitions.create('width')
   },
   divider: {
-    height: theme.spacing.unit * 2
+    height: theme.spacing(2)
   }
 });
 

--- a/main/src/components/card.js
+++ b/main/src/components/card.js
@@ -18,7 +18,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
   card: {
-    margin: theme.spacing.unit * 2
+    margin: theme.spacing(2)
   },
   innerContainer: {
     display: 'block',
@@ -40,24 +40,24 @@ const styles = theme => ({
       maxWidth: '100%',
       height: '9.375em',
       width: '16.625em',
-      margin: theme.spacing.unit * 2
+      margin: theme.spacing(2)
     }
   },
   chips: {
-    marginTop: theme.spacing.unit * 2,
-    marginBottom: theme.spacing.unit * 2
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
   },
   chip: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   fab: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   playCircleOutlineIcon: {
-    marginRight: theme.spacing.unit
+    marginRight: theme.spacing(1)
   },
   localPlayIcon: {
-    marginRight: theme.spacing.unit
+    marginRight: theme.spacing(1)
   }
 });
 

--- a/main/src/components/filterBar.js
+++ b/main/src/components/filterBar.js
@@ -32,10 +32,10 @@ const styles = theme => ({
     flexGrow: 1
   },
   formControl: {
-    margin: theme.spacing.unit * 3
+    margin: theme.spacing(3)
   },
   group: {
-    margin: `${theme.spacing.unit}px 0`,
+    margin: `${theme.spacing(1)}px 0`,
     top: '60px'
   },
   filterBar: {

--- a/main/src/components/footer.js
+++ b/main/src/components/footer.js
@@ -10,7 +10,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
   footer: {
-    margin: theme.spacing.unit * 2,
+    margin: theme.spacing(2),
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between'
@@ -24,7 +24,7 @@ const styles = theme => ({
     }
   },
   links: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   anchor: {
     textDecoration: 'none',

--- a/main/src/components/header.js
+++ b/main/src/components/header.js
@@ -41,12 +41,12 @@ const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.common.white, 0.25)
     },
-    marginRight: theme.spacing.unit * 2,
-    marginLeft: theme.spacing.unit * 2,
+    marginRight: theme.spacing(2),
+    marginLeft: theme.spacing(2),
     width: '100%'
   },
   searchIcon: {
-    width: theme.spacing.unit * 9,
+    width: theme.spacing(9),
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',

--- a/main/src/components/multiCard.js
+++ b/main/src/components/multiCard.js
@@ -19,7 +19,7 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
   card: {
-    margin: theme.spacing.unit * 2
+    margin: theme.spacing(2)
   },
   innerContainer: {
     display: 'block',
@@ -35,7 +35,7 @@ const styles = theme => ({
     }
   },
   description: {
-    marginTop: theme.spacing.unit
+    marginTop: theme.spacing(1)
   },
   thumbnail: {
     display: 'none',
@@ -44,20 +44,20 @@ const styles = theme => ({
       maxWidth: '100%',
       height: '9.375em',
       width: '16.625em',
-      margin: theme.spacing.unit * 2
+      margin: theme.spacing(2)
     }
   },
   chip: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   fab: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   playCircleOutlineIcon: {
-    marginRight: theme.spacing.unit
+    marginRight: theme.spacing(1)
   },
   localPlayIcon: {
-    marginRight: theme.spacing.unit
+    marginRight: theme.spacing(1)
   }
 });
 


### PR DESCRIPTION
Followed https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod/README.md#theme-spacing-api to replace `theme.spacing.unit x` with `theme.spacing(x)` using jscodeshift.

Fix #224 