### PR TITLE
remove tests from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged && yarn test:ci
+npx lint-staged


### PR DESCRIPTION
Resolves #277 

Removes test command from pre-commit to improve efficiency and DX.